### PR TITLE
Compile fixup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,13 @@ libs:
 		make -C $$dir ;\
 	done
 #
-execs:
+execs: bin
 	for dir in $(EXEC_DIR); do \
 		make -C $$dir; \
 	done
+#
+bin:
+	mkdir bin
 #
 install:
 	sh misc/stinstall

--- a/antcn/Makefile
+++ b/antcn/Makefile
@@ -1,6 +1,6 @@
 #
 CFLAGS= 
-LIBES = ../../fs/poclb/poclb.a ../../st/stlib/stlib.a ../../fs/clib/clib.a\
+LIBES = ../../fs/poclb/poclb.a ../stlib/stlib.a ../../fs/clib/clib.a\
 ../../fs/rtelb/rtelb.a -lm -lnsl
 #
 OBJECTS = antcn.o rad2str.o  # antcn_rpc_client.o antcn_rpc_clnt.o

--- a/antcn/STDDEFS.H
+++ b/antcn/STDDEFS.H
@@ -10,10 +10,6 @@ ENVIRONMENT: Any standard C with contiguous alphabetic codes (not EBCDIC)
 /*            various symbolic constants           */
 /***************************************************/
 
-#if	!defined (NULL) || (NULL != 0)
-#define NULL  0
-#endif
-
 #if	!defined (EOF) || (EOF != (-1))
 #define EOF  (-1)
 #endif

--- a/antcn/antcn.c
+++ b/antcn/antcn.c
@@ -95,7 +95,7 @@ main()
   int dum = 0;
   int r1, r2;
   int imode,i,nchar,n1,n2,nepoch;
-  long ip[5], class, clasr;
+  int ip[5], class, clasr;
   char buf[300], buf2[300];
 /*  Eff stuff */
 struct servent *sp;
@@ -117,9 +117,9 @@ struct hostent *hp;       /* host address */
    static char effband[9];            /* WHICH RF BAND IN USE */
    static int effpcal,efftcal;   /* pcal 0 off 1 on swcal 0 off 1 on */
    static float fflo;             /* gets lo frequenz*/
-   static long ifflo,iffcent; /*same , and rf_centre for comparison with what is read back from system*/
-   long isitgeo;
-   static long ifantenna; /*local copy of whats read back from antenna*/
+   static int ifflo,iffcent; /*same , and rf_centre for comparison with what is read back from system*/
+   int isitgeo;
+   static int ifantenna; /*local copy of whats read back from antenna*/
    char off1[30],off2[30];      /*for case 2 offsets: in arcsec*/
    
 /* end of eff stuff */

--- a/antcn/antcn.c
+++ b/antcn/antcn.c
@@ -67,14 +67,14 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "/usr2/fs/include/params.h" /* FS parameters            */
-#include "/usr2/fs/include/fs_types.h" /* FS header files        */
-#include "/usr2/fs/include/fscom.h"  /* FS shared mem. structure */
-#include "/usr2/fs/include/shm_addr.h" /* FS shared mem. pointer */
+#include "../../fs/include/params.h" /* FS parameters            */
+#include "../../fs/include/fs_types.h" /* FS header files        */
+#include "../../fs/include/fscom.h"  /* FS shared mem. structure */
+#include "../../fs/include/shm_addr.h" /* FS shared mem. pointer */
 
-#include "/usr2/st/include/stparams.h"
-#include "/usr2/st/include/stcom.h"
-#include "/usr2/st/include/stm_addr.h"   /* Station shared mem. pointer*/
+#include "../include/stparams.h"
+#include "../include/stcom.h"
+#include "../include/stm_addr.h"   /* Station shared mem. pointer*/
 
 struct fscom *fs;
 //struct stcom *st;

--- a/antcn/previous_antcn.c
+++ b/antcn/previous_antcn.c
@@ -70,14 +70,14 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "/usr2/fs/include/params.h" /* FS parameters            */
-#include "/usr2/fs/include/fs_types.h" /* FS header files        */
-#include "/usr2/fs/include/fscom.h"  /* FS shared mem. structure */
-#include "/usr2/fs/include/shm_addr.h" /* FS shared mem. pointer */
+#include "../../fs/include/params.h" /* FS parameters            */
+#include "../../fs/include/fs_types.h" /* FS header files        */
+#include "../../fs/include/fscom.h"  /* FS shared mem. structure */
+#include "../../fs/include/shm_addr.h" /* FS shared mem. pointer */
 
-#include "/usr2/st/include/stparams.h"
-#include "/usr2/st/include/stcom.h"
-#include "/usr2/st/include/stm_addr.h"   /* Station shared mem. pointer*/
+#include "../include/stparams.h"
+#include "../include/stcom.h"
+#include "../include/stm_addr.h"   /* Station shared mem. pointer*/
 
 struct fscom *fs;
 //struct stcom *st;

--- a/antcn/previous_antcn.c
+++ b/antcn/previous_antcn.c
@@ -98,7 +98,7 @@ main()
   int dum = 0;
   int r1, r2;
   int imode,i,nchar,n1,n2,nepoch;
-  long ip[5], class, clasr;
+  int ip[5], class, clasr;
   char buf[300], buf2[300];
 /*  Eff stuff */
 struct servent *sp;
@@ -120,9 +120,9 @@ struct hostent *hp;       /* host address */
    static char effband[9];            /* WHICH RF BAND IN USE */
    static int effpcal,efftcal;   /* pcal 0 off 1 on swcal 0 off 1 on */
    static float fflo;             /* gets lo frequenz*/
-   static long ifflo,iffcent; /*same , and rf_centre for comparison with what is read back from system*/
-   long isitgeo;
-   static long ifantenna; /*local copy of whats read back from antenna*/
+   static int ifflo,iffcent; /*same , and rf_centre for comparison with what is read back from system*/
+   int isitgeo;
+   static int ifantenna; /*local copy of whats read back from antenna*/
    char off1[30],off2[30];      /*for case 2 offsets: in arcsec*/
    
 /* end of eff stuff */

--- a/antcn/proto_antcn.c
+++ b/antcn/proto_antcn.c
@@ -70,7 +70,7 @@ main()
   int dum = 0;
   int r1, r2;
   int imode,i,nchar;
-  long ip[5], class, clasr;
+  int ip[5], class, clasr;
   char buf[80], buf2[100];
 
 /* Set up IDs for shared memory, then assign the pointer to

--- a/antcn/rad2str.c
+++ b/antcn/rad2str.c
@@ -79,7 +79,7 @@ BOOL round;        /* TRUE- output string is rouned, FALSE-truncated */
     BOOL lzero_flag = FALSE;    /* TRUE => use leading zeros fill */
     int sign_flag = 1;          /* 1=positive, -1=negative angle */
     register int i;
-    register long long_tmp;
+    register int long_tmp;
 
     /* decode measure type from format string */
     if (*pformat == 'h')
@@ -173,7 +173,7 @@ BOOL round;        /* TRUE- output string is rouned, FALSE-truncated */
 	angle -= long_tmp;     /* angle = fractional part of secs  */
         for (i = 0; i < n; i++)
             angle *= 10.0;
-        pstring += ltostr ((long)angle, pstring, -n, 0);
+        pstring += ltostr ((int)angle, pstring, -n, 0);
 	}
 //    *pstring++ = units_char[2];
     *pstring++ = '\0';
@@ -184,7 +184,7 @@ BOOL round;        /* TRUE- output string is rouned, FALSE-truncated */
 /*******************************************************************************
 */
 static int ltostr (number, pstring, width, sign)    /* convert long to string */
-long number;    /* number to be converted */
+int number;    /* number to be converted */
 char *pstring;  /* receiving string */
 int width;      /* minimum width of numeric field, positive width => use 
 		   leading blank fill, negative => leading zero fill */

--- a/antrcv/askvax.c
+++ b/antrcv/askvax.c
@@ -62,7 +62,7 @@ void logit();
 /*++******************************************************************/
 main ()    
 {
- long servport,cliport,mode,servsock,clisock,clilen;
+ int servport,cliport,mode,servsock,clisock,clilen;
  char clienttxt[BUFDIM],answertxt[BUFDIM];
  char buf2[300];
 
@@ -108,10 +108,10 @@ resock:                /*hhh restart here if system lost */
       char buf[ARGBUF];
       char ctemp[20],ctemp1[10];
       char bf1[30],bf6[30];
-      long scanmsec;
+      int scanmsec;
       float vv,vv1,vvtol;
       double vd;
-      long vl;
+      int vl;
       char *pp,*tmpch;
       int td1,td2,td3;
       float tf1;

--- a/antrcv/askvax.old.c
+++ b/antrcv/askvax.old.c
@@ -62,7 +62,7 @@ void logit();
 /*++******************************************************************/
 main ()    
 {
- long servport,cliport,mode,servsock,clisock,clilen;
+ int servport,cliport,mode,servsock,clisock,clilen;
  char clienttxt[BUFDIM],answertxt[BUFDIM];
 
  static int elaps,ioelaps,last_sentoff,last_ionsor,ln,lreached,stabletime;
@@ -106,10 +106,10 @@ resock:                /*hhh restart here if system lost */
       char buf[ARGBUF];
       char ctemp[20],ctemp1[10];
       char bf1[30],bf6[30];
-      long scanmsec;
+      int scanmsec;
       float vv,vv1,vvtol;
       double vd;
-      long vl;
+      int vl;
       char *pp,*tmpch;
       int td1,td2,td3;
       float tf1;

--- a/antrcv/clientserv.c
+++ b/antrcv/clientserv.c
@@ -35,14 +35,14 @@ struct fscom *fs;
 /* Subroutines called */
 void setup_ids();
 void logit();
-long server_bind(long *mode,long *portnum,long *fsock,char *errortxt);
-long socket_sendto(long *portnum,long *sock,char *buf,long *fbuflen
+int server_bind(int *mode,int *portnum,int *fsock,char *errortxt);
+int socket_sendto(int *portnum,int *sock,char *buf,int *fbuflen
                   ,char *hostaddr);
-long socket_rcvfrom(long *fsock,char *buf,long *fbuflen,char *clientaddr);
+int socket_rcvfrom(int *fsock,char *buf,int *fbuflen,char *clientaddr);
 void bytezero(char *dest,int bytes);
-void callerror(char *errortext,long severity);
-long addr_file(char *filename,long *maxnr,long portcli[],char *hostaddr[]);
-long check_address(long *maxnr,char *addrfeld[],char *iaddr);
+void callerror(char *errortext,int severity);
+int addr_file(char *filename,int *maxnr,int portcli[],char *hostaddr[]);
+int check_address(int *maxnr,char *addrfeld[],char *iaddr);
 /* antrcv main program starts here */
 /* eff setup socket stuff */
 /*---------------------------------------------------------------------*/
@@ -50,11 +50,11 @@ long check_address(long *maxnr,char *addrfeld[],char *iaddr);
 /*++******************************************************************/
 main ()    
 {
- long servport,cliport,mode,servsock,clisock,clilen;
+ int servport,cliport,mode,servsock,clisock,clilen;
  char clienttxt[BUFDIM],answertxt[BUFDIM];
  char *serverfile=ADRESSENFILE;
  BOOL senden=FALSE;  
- long icond,max=MAXX,cliports[MAXX],i,ianz;
+ int icond,max=MAXX,cliports[MAXX],i,ianz;
  char *hosts[MAXX];
  char hostaddr[MAXX][80];
 
@@ -214,16 +214,16 @@ char s[],t; int n;
 }
 /* - - - - - - - - - - - - - - - - - - - -*/
 
-long server_bind(long *fmode,long *portnum,long *fsock,char *errortxt)
+int server_bind(int *fmode,int *portnum,int *fsock,char *errortxt)
 /*                               Version 05.02.96 / jn */
 {
  static struct sockaddr_in  server;
 
  int addrlen,sock,type,protocol,mode;
- long portnumber,iret;
+ int portnumber,iret;
  int x=1; /*hhhh*/
 
-  portnumber=(long)*portnum;
+  portnumber=(int)*portnum;
   mode=(int)*fmode;
 
 /*  Verbindungsmode festlegen   */
@@ -236,7 +236,7 @@ long server_bind(long *fmode,long *portnum,long *fsock,char *errortxt)
     
    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char *)&x, sizeof(x));
 
-  *fsock=(long)sock;
+  *fsock=(int)sock;
   addrlen=sizeof(server);
   bytezero((char *)&server,addrlen);
   server.sin_family = AF_INET;
@@ -256,17 +256,17 @@ ende:
   return(iret);
 }
 
-long socket_sendto(long *portnum,long *fsock,char *buf,long *fbuflen
+int socket_sendto(int *portnum,int *fsock,char *buf,int *fbuflen
                   ,char *hostaddr)
 /*                               Version 05.02.96 / jn */
 {
  struct sockaddr_in host; 
 
  int rval,flags,addrlen,buflen,sock;
- long portnumber,iret;
+ int portnumber,iret;
 
   sock=(int)*fsock;
-  portnumber=(long)*portnum;
+  portnumber=(int)*portnum;
   buflen=(int)*fbuflen;
   flags=0;
 
@@ -291,13 +291,13 @@ long socket_sendto(long *portnum,long *fsock,char *buf,long *fbuflen
 
 }
 
-long socket_rcvfrom(long *fsock,char *buf,long *fbuflen
+int socket_rcvfrom(int *fsock,char *buf,int *fbuflen
                    ,char *clientaddr)
 /*                               Version 05.02.96 / jn */
 {
  static struct sockaddr_in  client;
  int rval,flags,addrlen,buflen,sock;
- long iret;
+ int iret;
   buflen=(int)*fbuflen;
   sock=(int)*fsock;
   flags=0;
@@ -319,23 +319,23 @@ long socket_rcvfrom(long *fsock,char *buf,long *fbuflen
         iret=0; return(iret);   /* rval -1 just means no reply    */
 }
 
-long check_address(long *maxnr,char *addrfeld[],char *iaddr)
+int check_address(int *maxnr,char *addrfeld[],char *iaddr)
 /*                               Version 05.02.96 / jn */
 {
   int i,max,icond;
-  long iret;
+  int iret;
   max=(int)*maxnr;
   for (i=0;i<max;i++)
       { 
        if ( (icond=(int)strstr(addrfeld[i],iaddr)) != 0 ) 
-          { iret=(long)i; return(iret); }                   /* gefunden */    
+          { iret=(int)i; return(iret); }                   /* gefunden */    
       }
 
   iret= -1;
   return(iret);
 }
 
-void callerror(char *errortext,long severity)
+void callerror(char *errortext,int severity)
 /*                               Version 23.01.96 / jn */
 {
    switch (severity) 

--- a/antrcv/dummy_telescope_askvax.c
+++ b/antrcv/dummy_telescope_askvax.c
@@ -92,11 +92,11 @@ main ()
       char buf[ARGBUF];
       char ctemp[20],ctemp1[10];
       char bf1[30],bf6[30];
-      long scanmsec;
+      int scanmsec;
       float vv,vv1,vvtol;
       float aoff,eoff,toff,tof1,tof2;
       double vd;
-      long vl;
+      int vl;
       char *pp,*tmpch;
       int td1,td2,td3;
       float tf1;

--- a/antrcv/real_askvax.c
+++ b/antrcv/real_askvax.c
@@ -62,7 +62,7 @@ void logit();
 /*++******************************************************************/
 main ()    
 {
- long servport,cliport,mode,servsock,clisock,clilen;
+ int servport,cliport,mode,servsock,clisock,clilen;
  char clienttxt[BUFDIM],answertxt[BUFDIM];
 
  static int elaps,ioelaps,last_sentoff,last_ionsor,ln,lreached,stabletime;
@@ -106,10 +106,10 @@ resock:                /*hhh restart here if system lost */
       char buf[ARGBUF];
       char ctemp[20],ctemp1[10];
       char bf1[30],bf6[30];
-      long scanmsec;
+      int scanmsec;
       float vv,vv1,vvtol;
       double vd;
-      long vl;
+      int vl;
       char *pp,*tmpch;
       int td1,td2,td3;
       float tf1;

--- a/antrcv/sockdefs.h
+++ b/antrcv/sockdefs.h
@@ -26,10 +26,10 @@
 #define FOREVER   for(;;) {
 #define ENDFOREVER   }
 
-#define FATAL					(long)-1
-#define NORMAL				(long)1
-#define INFORM				(long)0
-#define ADDSYSERR		(long)-999    
+#define FATAL					(int)-1
+#define NORMAL				(int)1
+#define INFORM				(int)0
+#define ADDSYSERR		(int)-999    
 
 #define SOCK_ADDR_SIZE		(sizeof (struct sockaddr_in))
 #define MAX_QUEUED_CONNECTIONS	(4)

--- a/cheks/cheks.c
+++ b/cheks/cheks.c
@@ -30,7 +30,7 @@ void skd_run(), skd_par();            /* program scheduling utilities */
 
 main()
 {
-  long ip[5];
+  int ip[5];
   int nreport, checks, i, j;
   int ierr[MAX_ERR];
 

--- a/hpcounter/Makefile
+++ b/hpcounter/Makefile
@@ -1,5 +1,5 @@
 CFLAGS=-g
-LIBS = /usr2/fs/port/port.a /usr2/st/stlib/stlib.a  -lfl
+LIBS = ../../fs/port/port.a ../stlib/stlib.a  -lfl
 OBJECTS = hpcounter.o
 #
 ../bin/hpcounter: hpcounter.o $(OBJECTS)

--- a/hpcounter/getgps.c
+++ b/hpcounter/getgps.c
@@ -16,7 +16,7 @@ extern struct fscom *fs;
 /*get gps value from truetime and log it when asked for*/
 void getgps(command,ip,isub,iresult)
 struct cmd_ds *command;
-long ip[5];
+int ip[5];
 int isub,iresult;
 {
    int i,ierr;

--- a/hpcounter/hpcounter.c
+++ b/hpcounter/hpcounter.c
@@ -35,7 +35,7 @@ main(int argc, char *argv[])
   int i,iii;
   int read_errors=0;
   int write_errors=0;
-  long idiff;
+  int idiff;
   double tdiff,tdiffout;
   
   setup_st();

--- a/include/stcom.h
+++ b/include/stcom.h
@@ -5,7 +5,7 @@ typedef struct stcom {
   int dummy;              /* just a dummy */
   int ieffcal;            /* 0 for frontend cal off, 1 for cal on */
   int ieffpcal;           /* 0 for phase cal off, 1 for pcal on */
-  long ieffrx;            /* what receiver (now lo frequency)*/
+  int ieffrx;            /* what receiver (now lo frequency)*/
   int rx_bits;            /* these are the 16bits sent to the SBC ,
                              top bit is cal offon */
   int antenna_sentoff;    /* if =1, antenna has just got new source command or azel offset, 
@@ -19,7 +19,7 @@ typedef struct stcom {
 			      in normal VLBI mode but but 0 if on/off or fivpt)
 			    4=stable on source (ionsor=1)*/
   int ant_scanning;       /*from vaxtime, -ve if waiting, + if scanning (scanmsec)*/
-  long ant_rfcentre;      /* from vaxtime broadcast: centre freq reported back from antenna,
+  int ant_rfcentre;      /* from vaxtime broadcast: centre freq reported back from antenna,
 			     should agree with value in rxlist table , if not, try to resend..*/
   double fsynth1,fsynth2; /*front end synthesizer(ULO) and 2nd LO synth in MHz*/
   int ant_is_listening;   /*controlled and read by rxvt, =1 if antenna is receiving commands from 

--- a/inject_snap/inject_snap.c
+++ b/inject_snap/inject_snap.c
@@ -43,14 +43,14 @@ extern struct fscom *shm_addr;
 /* External FS functions, perhaps these should eventually go into a '.h'? */
 extern void setup_ids(void);
 extern void sig_ignore(void);
-extern void cls_snd(long *class,
+extern void cls_snd(int *class,
 		    char *buffer,
 		    int length,
 		    int parm3,
 		    int parm4);
-extern void skd_run(char name[5], char w, long ip[5]);
+extern void skd_run(char name[5], char w, int ip[5]);
 
-static long ipr[5] = { 0, 0, 0, 0, 0};
+static int ipr[5] = { 0, 0, 0, 0, 0};
 
 /* The dynamically allocated SNAP command table. */
 

--- a/pcald/pcald.c
+++ b/pcald/pcald.c
@@ -22,7 +22,7 @@ extern struct fscom *shm_addr;
 
 main()
 {
-  long ip[5];
+  int ip[5];
   struct pcald_cmd pcald;
   struct data_valid_cmd data_valid[2];
   int i,j,k,l,idata;

--- a/stalloc/stalloc.c
+++ b/stalloc/stalloc.c
@@ -5,11 +5,11 @@
 #include <sys/ipc.h>
 #include <stdlib.h>
 
-#include "/usr2/fs/include/params.h"
-#include "/usr2/fs/include/fs_types.h"
-#include "/usr2/st/include/stparams.h"
-#include "/usr2/st/include/stcom.h"
-#include "/usr2/st/include/stm_addr.h"
+#include "../../fs/include/params.h"
+#include "../../fs/include/fs_types.h"
+#include "../include/stparams.h"
+#include "../include/stcom.h"
+#include "../include/stm_addr.h"
 
 main()
 {

--- a/sterp/get_err.c
+++ b/sterp/get_err.c
@@ -14,7 +14,7 @@
 void get_err(buffer,maxlen,ip)
 char buffer[];
 int maxlen;
-long ip[5];
+int ip[5];
 {
 
   skd_arg_buff(buffer,maxlen);

--- a/sterp/sterp.c
+++ b/sterp/sterp.c
@@ -31,7 +31,7 @@ void get_err();
 
 main()
 {
-  long ip[5];
+  int ip[5];
   char buffer[MAX_LEN];
 
 /* Initialize:

--- a/stqkr/donoff.c
+++ b/stqkr/donoff.c
@@ -27,7 +27,7 @@ float flux_val();
 void donoff(command,itask,ip)
 struct cmd_ds *command;                /* parsed command structure */
 int itask;
-long ip[5];                           /* ipc parameters */
+int ip[5];                           /* ipc parameters */
 {
       int ilast, ierr, ichold, i, count, j;
       int verr;
@@ -168,7 +168,7 @@ long ip[5];                           /* ipc parameters */
 	      if(lcl.devices[i].ifchain<1||lcl.devices[i].ifchain>4)
 		lcl.devices[i].ifchain=0;
 	      if(lcl.devices[i].ifchain!=0) {
-		long bbc2freq();
+		int bbc2freq();
 		float freq, bbcbw;
 		
 		freq=bbc2freq(shm_addr->bbc[i%MAX_BBC].freq)/100.0;

--- a/stqkr/donoff.c
+++ b/stqkr/donoff.c
@@ -5,11 +5,11 @@
 #include <string.h> 
 #include <sys/types.h>
 
-#include "/usr2/fs/include/dpi.h"
-#include "/usr2/fs/include/params.h"
-#include "/usr2/fs/include/fs_types.h"
-#include "/usr2/fs/include/fscom.h"         /* shared memory definition */
-#include "/usr2/fs/include/shm_addr.h"      /* shared memory pointer */
+#include "../../fs/include/dpi.h"
+#include "../../fs/include/params.h"
+#include "../../fs/include/fs_types.h"
+#include "../../fs/include/fscom.h"         /* shared memory definition */
+#include "../../fs/include/shm_addr.h"      /* shared memory pointer */
 
 static char hex[]= "0123456789abcdef";
 static char det[] = "dlu34567";

--- a/stqkr/effcal.c
+++ b/stqkr/effcal.c
@@ -16,7 +16,7 @@ extern struct fscom *fs;
 
 void effcal(command,ip,isub,iresult)
 struct cmd_ds *command;
-long ip[5];
+int ip[5];
 int isub,iresult;
 {
    static int ieffcal;

--- a/stqkr/efflo.c
+++ b/stqkr/efflo.c
@@ -20,7 +20,7 @@ extern struct fscom *fs;
  where parameters from rcp on only for VeEX */
 void efflo(command,ip,isub,iresult)
 struct cmd_ds *command;
-long ip[5];
+int ip[5];
 int isub,iresult;
 {
    static float floa,flob;

--- a/stqkr/effpatch.c
+++ b/stqkr/effpatch.c
@@ -18,7 +18,7 @@ extern struct stcom *st;
 /* replacement patch command, mk4 only, includes call to Eff patch device*/
 void effpatch(command,ip,isub,iresult)
 struct cmd_ds *command;
-long ip[5];
+int ip[5];
 int isub,iresult;
 {
 //   static int last_patch_set[16];

--- a/stqkr/effpcal.c
+++ b/stqkr/effpcal.c
@@ -22,7 +22,7 @@ extern struct fscom *fs;
     to synchronize reported state with hardware */
 void effpcal(command,ip,isub,iresult)
 struct cmd_ds *command;
-long ip[5];
+int ip[5];
 int isub,iresult;
 {
    static int ieffpcal;

--- a/stqkr/effrx.c
+++ b/stqkr/effrx.c
@@ -16,7 +16,7 @@ extern struct fscom *fs;
 
 void effrx(command,ip,isub,iresult)
 struct cmd_ds *command;
-long ip[5];
+int ip[5];
 int isub,iresult;
 {
    static int ieffrx;

--- a/stqkr/effwx.c
+++ b/stqkr/effwx.c
@@ -16,7 +16,7 @@ extern struct fscom *fs;
 
 void effwx(command,ip,isub,iresult)
 struct cmd_ds *command;
-long ip[5];
+int ip[5];
 int isub,iresult;
 {
    int i ,ierr;

--- a/stqkr/getgps.c
+++ b/stqkr/getgps.c
@@ -17,7 +17,7 @@ extern struct fscom *fs;
 /*get gps value from hp counter and log it when asked for*/
 void getgps(command,ip,isub,iresult)
 struct cmd_ds *command;
-long ip[5];
+int ip[5];
 int isub,iresult;
 {
    FILE *fp;

--- a/stqkr/onoff_dis.c
+++ b/stqkr/onoff_dis.c
@@ -13,7 +13,7 @@
 
 void onoff_dis(command,ip)
 struct cmd_ds *command;
-long ip[5];
+int ip[5];
 {
       struct onoff_cmd lclc;
       int kcom, i, ierr, count, start;

--- a/stqkr/onoff_dis.c
+++ b/stqkr/onoff_dis.c
@@ -4,10 +4,10 @@
 #include <string.h>
 #include <sys/types.h>
 
-#include "/usr2/fs/include/params.h"
-#include "/usr2/fs/include/fs_types.h"
-#include "/usr2/fs/include/fscom.h"
-#include "/usr2/fs/include/shm_addr.h"
+#include "../../fs/include/params.h"
+#include "../../fs/include/fs_types.h"
+#include "../../fs/include/fscom.h"
+#include "../../fs/include/shm_addr.h"
 
 #define MAX_OUT 256
 

--- a/stqkr/stqkr.c
+++ b/stqkr/stqkr.c
@@ -19,9 +19,9 @@ struct fscom *fs;
 
 main()
 {
-    long ip[5];
-    long ipsave[5];
-    long outclass;
+    int ip[5];
+    int ipsave[5];
+    int outclass;
     int isub,itask,idum,ierr,nchars,i;
     char buf[MAX_BUF];
     char copy_buf[MAX_BUF];


### PR DESCRIPTION
This is a first draft for making this code 32/64-bit compatible.

Changes (commits):

1. Make all includes relative
1. Create _bin/_ automatically
1. Remove conflicting `#if `for `NULL` in _antcn/STDDEFS.H_
1. Apply _unlongify_

Sometimes _unlongify_ can change some `long` variables that need to be `int`, usually for system calls, but I did not see any obvious problems. There were a few previously `long` variables that did not seem to be used. There were also a few that seemed to exist only to be converted to `int` by assignments. There may be some format conversions in commented out I/O statements that may still need to be converted from `%ld` to `%d`. There were some existing `%d` conversions that looked like they should have been `%ld`, but that should be okay now that the variables are in `int`. Generally `long` is rarely needed, but please check the changes in that commit carefully.

I didn't understand the problem in _antcn/STDDEFS.H_, but I think the fix should be benign.